### PR TITLE
support category_layout found in themes: gem-based themes and remote themes

### DIFF
--- a/lib/jekyll/category_pages.rb
+++ b/lib/jekyll/category_pages.rb
@@ -153,7 +153,12 @@ module Jekyll
     # use_paginator     - Whether a CategoryPager object shall be instantiated as 'paginator'.
     def initialize(site, dir, page_name, category, category_layout, posts_in_category, use_paginator)
       @site = site
-      @base = site.theme ? site.theme.root : site.source
+      @base = site.source
+      if ! File.exist?(File.join(@base, category_layout)) && 
+        ( site.theme && File.exist?(File.join(site.theme.root, category_layout)) )
+          @base = site.theme.root
+      end
+      
       super(@site, @base, '', category_layout)
       @dir = dir
       @name = page_name

--- a/lib/jekyll/category_pages.rb
+++ b/lib/jekyll/category_pages.rb
@@ -153,7 +153,7 @@ module Jekyll
     # use_paginator     - Whether a CategoryPager object shall be instantiated as 'paginator'.
     def initialize(site, dir, page_name, category, category_layout, posts_in_category, use_paginator)
       @site = site
-      @base = site.source
+      @base = site.theme ? site.theme.root : site.source
       super(@site, @base, '', category_layout)
       @dir = dir
       @name = page_name


### PR DESCRIPTION
Hi,

I just wanted to add support for category_layout found in themes: gem-based themes and remote themes. My projects need to use category_layout in gem-based themes or remote themes but I got file not found error `_layouts/category_index.html: No such file or directory`. So I went ahead and made some changes to have it work with other types of theme. I run your all test cases and all passed. I want to add some test cases which will need to update Gemfile files. Do you mind that?

I think this is helpful to others too. Theme authors also need this PR to be able to include category_layout for their themes.

Let me know if you have any questions or need anything.

Thank you!